### PR TITLE
Use Normal string for QOTD and add Edit QOTD button and modal

### DIFF
--- a/modules/events/button_click.py
+++ b/modules/events/button_click.py
@@ -115,7 +115,7 @@ class OnButtonClick(commands.Cog):
             Log.info(f"A message report was closed by {inter.author.name}")
         if inter.component.custom_id == "edit_qotd_msg":
             # admin or mods
-            if "935560587113541633" in inter.user.roles or "935629680520855552" in inter.user.roles:
+            if "935560587113541633" in inter.author.roles or "935629680520855552" in inter.author.roles:
                 await inter.response.send_modal(EditQOTDModal())
             else:
                 await inter.response.send_message("No permission", ephemeral=True)

--- a/modules/events/button_click.py
+++ b/modules/events/button_click.py
@@ -1,9 +1,11 @@
+import datetime
+
 import disnake
 from disnake.ext import commands
-import variables
-import datetime
+
 import utils.log as Log
-from utils.stats import update
+import variables
+from modules.qotd.schedule import EditQOTDModal
 from utils.res_thread import resolve_thread
 
 
@@ -111,3 +113,9 @@ class OnButtonClick(commands.Cog):
             await inter.response.send_message("Closed the report",ephemeral=True)
             
             Log.info(f"A message report was closed by {inter.author.name}")
+        if inter.component.custom_id == "edit_qotd_msg":
+            # admin or mods
+            if "935560587113541633" in inter.user.roles or "935629680520855552" in inter.user.roles:
+                await inter.response.send_modal(EditQOTDModal())
+            else:
+                await inter.response.send_message("No permission", ephemeral=True)

--- a/modules/qotd/schedule.py
+++ b/modules/qotd/schedule.py
@@ -24,7 +24,7 @@ async def schedule_qotd(bot: InteractionBot):
         
         async for message in input_channel.history(limit=200):
             # If already posted, skip
-            if '✅' in message.reactions or message.content is str or message.author.bot:
+            if '✅' in message.reactions or message.content is not str or message.author.bot:
                 continue
             
             # Check it follows the correct format

--- a/modules/qotd/schedule.py
+++ b/modules/qotd/schedule.py
@@ -24,7 +24,7 @@ async def schedule_qotd(bot: InteractionBot):
         
         async for message in input_channel.history(limit=200):
             # If already posted, skip
-            if '✅' in message.reactions or message.content is not str or message.author.bot:
+            if '✅' in message.reactions or type(message.content) != str or message.author.bot:
                 continue
             
             # Check it follows the correct format


### PR DESCRIPTION
This pull request simply changes how the bot prints out automated QOTD messages so that they show up in the forum post short description. In addition, it also adds an edit button to edit the message after the bot has sent it (in case of spelling mistakes)